### PR TITLE
API ECS deploy

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,5 +1,5 @@
 NODE_ENV=production
-APP_TITLE=React Calendar API
+APP_TITLE=SpeedCal
 APP_URL=http://localhost
 PORT=3000
 API_PORT=3001

--- a/.github/aws/task-definition.json
+++ b/.github/aws/task-definition.json
@@ -4,11 +4,8 @@
     "networkMode": "awsvpc",
     "containerDefinitions": [
         {
-            "name": "",
-            "image": "",
-            "repositoryCredentials": {
-                "credentialsParameter": ""
-            },
+            "name": "speedcal-api",
+            "image": "942897609521.dkr.ecr.us-west-2.amazonaws.com/speedcal-api-ecr",
             "cpu": 256,
             "memory": 512,
             "memoryReservation": 512,

--- a/.github/aws/task-definition.json
+++ b/.github/aws/task-definition.json
@@ -12,7 +12,7 @@
             "portMappings": [
                 {
                     "containerPort": 3001,
-                    "hostPort": 80,
+                    "hostPort": 3001,
                     "protocol": "tcp"
                 }
             ],

--- a/.github/aws/task-definition.json
+++ b/.github/aws/task-definition.json
@@ -23,13 +23,6 @@
                     "value": "AWS"
                 }
             ],
-            "linuxParameters": {
-                "capabilities": {},
-                "devices": [],
-                "initProcessEnabled": true,
-                "sharedMemorySize": 0,
-                "tmpfs": []
-            },
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {

--- a/.github/aws/task-definition.json
+++ b/.github/aws/task-definition.json
@@ -1,76 +1,53 @@
 {
-    "taskDefinition": {
-        "taskDefinitionArn": "arn:aws:ecs:us-west-2:942897609521:task-definition/speedcal-api-task-definition:1",
-        "containerDefinitions": [
-            {
-                "name": "sample-app",
-                "image": "httpd:2.4",
-                "cpu": 256,
-                "memoryReservation": 512,
-                "links": [],
-                "portMappings": [
-                    {
-                        "containerPort": 80,
-                        "hostPort": 80,
-                        "protocol": "tcp"
-                    }
-                ],
-                "essential": true,
-                "entryPoint": [
-                    "sh",
-                    "-c"
-                ],
-                "command": [
-                    "/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground\""
-                ],
-                "environment": [],
-                "mountPoints": [],
-                "volumesFrom": [],
-                "logConfiguration": {
-                    "logDriver": "awslogs",
-                    "options": {
-                        "awslogs-group": "/ecs/speedcal-api-task-definition",
-                        "awslogs-region": "us-west-2",
-                        "awslogs-stream-prefix": "ecs"
-                    }
+    "family": "speedcal-api-task-definition",
+    "executionRoleArn": "arn:aws:iam::942897609521:role/ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "containerDefinitions": [
+        {
+            "name": "",
+            "image": "",
+            "repositoryCredentials": {
+                "credentialsParameter": ""
+            },
+            "cpu": 256,
+            "memory": 512,
+            "memoryReservation": 512,
+            "portMappings": [
+                {
+                    "containerPort": 3001,
+                    "hostPort": 80,
+                    "protocol": "tcp"
+                }
+            ],
+            "essential": true,
+            "environment": [
+                {
+                    "name": "ENV",
+                    "value": "AWS"
+                }
+            ],
+            "linuxParameters": {
+                "capabilities": {},
+                "devices": [],
+                "initProcessEnabled": true,
+                "sharedMemorySize": 0,
+                "tmpfs": []
+            },
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/speedcal-api-task-definition",
+                    "awslogs-region": "us-west-2",
+                    "awslogs-stream-prefix": "ecs"
                 }
             }
-        ],
-        "family": "speedcal-api-task-definition",
-        "executionRoleArn": "arn:aws:iam::942897609521:role/ecsTaskExecutionRole",
-        "networkMode": "awsvpc",
-        "revision": 1,
-        "volumes": [],
-        "status": "ACTIVE",
-        "requiresAttributes": [
-            {
-                "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-            },
-            {
-                "name": "ecs.capability.execution-role-awslogs"
-            },
-            {
-                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-            },
-            {
-                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.21"
-            },
-            {
-                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-            },
-            {
-                "name": "ecs.capability.task-eni"
-            }
-        ],
-        "placementConstraints": [],
-        "compatibilities": [
-            "EC2",
-            "FARGATE"
-        ],
-        "requiresCompatibilities": [
-            "FARGATE"
-        ],
-        "cpu": "256",
-        "memory": "512"
-    }
+        }
+    ],
+    "volumes": [],
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "256",
+    "memory": "512"
 }

--- a/.github/aws/task-definition.json
+++ b/.github/aws/task-definition.json
@@ -1,0 +1,76 @@
+{
+    "taskDefinition": {
+        "taskDefinitionArn": "arn:aws:ecs:us-west-2:942897609521:task-definition/speedcal-api-task-definition:1",
+        "containerDefinitions": [
+            {
+                "name": "sample-app",
+                "image": "httpd:2.4",
+                "cpu": 256,
+                "memoryReservation": 512,
+                "links": [],
+                "portMappings": [
+                    {
+                        "containerPort": 80,
+                        "hostPort": 80,
+                        "protocol": "tcp"
+                    }
+                ],
+                "essential": true,
+                "entryPoint": [
+                    "sh",
+                    "-c"
+                ],
+                "command": [
+                    "/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground\""
+                ],
+                "environment": [],
+                "mountPoints": [],
+                "volumesFrom": [],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": "/ecs/speedcal-api-task-definition",
+                        "awslogs-region": "us-west-2",
+                        "awslogs-stream-prefix": "ecs"
+                    }
+                }
+            }
+        ],
+        "family": "speedcal-api-task-definition",
+        "executionRoleArn": "arn:aws:iam::942897609521:role/ecsTaskExecutionRole",
+        "networkMode": "awsvpc",
+        "revision": 1,
+        "volumes": [],
+        "status": "ACTIVE",
+        "requiresAttributes": [
+            {
+                "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+            },
+            {
+                "name": "ecs.capability.execution-role-awslogs"
+            },
+            {
+                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+            },
+            {
+                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.21"
+            },
+            {
+                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+            },
+            {
+                "name": "ecs.capability.task-eni"
+            }
+        ],
+        "placementConstraints": [],
+        "compatibilities": [
+            "EC2",
+            "FARGATE"
+        ],
+        "requiresCompatibilities": [
+            "FARGATE"
+        ],
+        "cpu": "256",
+        "memory": "512"
+    }
+}

--- a/.github/aws/task-definition.json
+++ b/.github/aws/task-definition.json
@@ -18,10 +18,9 @@
             ],
             "essential": true,
             "environment": [
-                {
-                    "name": "ENV",
-                    "value": "AWS"
-                }
+                {"name": "ENV", "value": "AWS"},
+                {"name": "APP_URL", "value": "http://dev.speedcal.date"},
+                {"name": "PORT", "value": "80"}
             ],
             "logConfiguration": {
                 "logDriver": "awslogs",

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -29,11 +29,14 @@
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches:
-      - dev
 
-name: Deploy to Amazon ECS
+  pull_request:
+    branches: [ dev ]
+    paths-ignore:
+    - 'src/**'
+    - 'test/app/**'
+
+name: Deploy API to Amazon ECS
 
 jobs:
   deploy:
@@ -65,7 +68,8 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        #docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        npm run api:docker:build
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -1,0 +1,86 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, when a release is created
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name speedcal-api-ecr --region us-west-2`.
+#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
+#    Replace the value of `aws-region` in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/firstRun
+#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
+#    Replace the value of `container-name` in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+#on:
+#  release:
+#    types: [created]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches:
+      - dev
+
+name: Deploy to Amazon ECS
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: speedcal-api-ecr
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: .github/aws/task-definition.json
+        container-name: speedcal-api
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: sample-app-service
+        cluster: default
+        wait-for-service-stability: true

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -40,7 +40,7 @@ name: Deploy API to Amazon ECS
 
 jobs:
   deploy:
-    name: Deploy
+    name: Deploy API
     runs-on: ubuntu-latest
 
     steps:
@@ -84,6 +84,6 @@ jobs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: sample-app-service
-        cluster: default
+        service: speedcal-api-service
+        cluster: speedcal-api
         wait-for-service-stability: true

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -1,31 +1,5 @@
-# This workflow will build and push a new container image to Amazon ECR,
-# and then will deploy a new task definition to Amazon ECS, when a release is created
-#
-# To use this workflow, you will need to complete the following set-up steps:
-#
-# 1. Create an ECR repository to store your images.
-#    For example: `aws ecr create-repository --repository-name speedcal-api-ecr --region us-west-2`.
-#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
-#    Replace the value of `aws-region` in the workflow below with your repository's region.
-#
-# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
-#    For example, follow the Getting Started guide on the ECS console:
-#      https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/firstRun
-#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
-#
-# 3. Store your ECS task definition as a JSON file in your repository.
-#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
-#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
-#    Replace the value of `container-name` in the workflow below with the name of the container
-#    in the `containerDefinitions` section of the task definition.
-#
-# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
-#    and best practices on handling the access key credentials.
+name: Deploy API to Amazon ECS
 
-#on:
-#  release:
-#    types: [created]
 on:
   push:
     branches: [ master ]
@@ -35,8 +9,6 @@ on:
     paths-ignore:
     - 'src/**'
     - 'test/app/**'
-
-name: Deploy API to Amazon ECS
 
 jobs:
   deploy:
@@ -65,9 +37,6 @@ jobs:
         ECR_REPOSITORY: speedcal-api-ecr
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        # Build a docker container and
-        # push it to ECR so that it can
-        # be deployed to ECS.
         docker build -f docker/api/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -68,8 +68,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        #docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        npm run api:docker:build
+        docker build -f docker/api/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/api-test-dev.yml
+++ b/.github/workflows/api-test-dev.yml
@@ -5,10 +5,14 @@ name: API:dev
 
 on:
   push:
-    branches: [ master ]
+    branches: [ dev ]
+    paths:
+    - api
+
   pull_request:
-    branches:
-      - dev
+    branches: [ dev ]
+    paths:
+    - api
 
 jobs:
   build:

--- a/.github/workflows/api-test-dev.yml
+++ b/.github/workflows/api-test-dev.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: API:dev
 
 on:

--- a/.github/workflows/api-test-master.yml
+++ b/.github/workflows/api-test-master.yml
@@ -7,8 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches:
-      - master
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/api-test-master.yml
+++ b/.github/workflows/api-test-master.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: API:master
 
 on:

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -3,9 +3,18 @@ name: Upload Frontend
 on:
   push:
     branches: [ master, dev ]
+    paths:
+    - src
+    - public
+    - build
+    - '.github/workflows/app-deploy.yml'
   pull_request:
-    branches: 
-    - dev
+    branches: [ dev ]
+    paths:
+    - src
+    - public
+    - build
+    - '.github/workflows/app-deploy.yml'
 
 jobs:
   build:

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>SpeedCal - Quick embeddable calendar images</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Adds an ECS deploy workflow.

## Verification

- [x] Try hitting the front end: http://dev.speedcal.date/?events=2020-4-14&title=testt
- [x] Render an image with the api: http://dev.api.speedcal.date:3001/?events=2020-4-14&title=testt

Log in to the AWS account, then...

- [x] Check out the [DNS records](https://console.aws.amazon.com/route53/home?region=us-west-2#resource-record-sets:Z09535602EUU688P9RI4T). The "alias" records point to the S3 bucket for the app, and a load balancer for the API.
- [ ] Check out the [ECR registry](https://us-west-2.console.aws.amazon.com/ecr/repositories/speedcal-api-ecr/?region=us-west-2) - this is where the Docker images built by the CI are stored.
- [ ] Check out the [ECS clusters](https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/clusters) - this is where the API containers are defined and described.